### PR TITLE
Do not send new commands until ack is returned

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,7 +191,7 @@ class instance extends instance_skel {
 	}
 
 	initPolling() {
-		if (this.pollMixerTimer === undefined) {
+		if (this.pollMixerTimer === undefined && this.config.poll_interval > 0) {
 			this.pollMixerTimer = setInterval(() => {
 				if(!this.cmdPipe.includes('QPL:7')) { // No need to flood the buffer with these
 					this.sendCommmand('QPL:7')
@@ -220,10 +220,10 @@ class instance extends instance_skel {
 			{
 				type: 'number',
 				id: 'poll_interval',
-				label: 'Polling Interval (ms)',
-				min: 300,
+				label: 'Polling Interval (ms), set to 0 to disable polling',
+				min: 0,
 				max: 30000,
-				default: 500,
+				default: 0,
 				width: 8,
 			},
 		]

--- a/index.js
+++ b/index.js
@@ -90,6 +90,7 @@ class instance extends instance_skel {
 			})
 
 			this.socket.on('connect', () => {
+				this.cmdPipe = []
 				debug('Connected')
 			})
 
@@ -127,7 +128,6 @@ class instance extends instance_skel {
 			const return_cmd = this.cmdPipe.shift()
 
 			if(this.cmdPipe.length > 0) {
-				console.log(this.cmdPipe)
 				this.socket.send('\u0002' + this.cmdPipe[0] + ';')
 			}
 

--- a/index.js
+++ b/index.js
@@ -239,6 +239,7 @@ class instance extends instance_skel {
 						label: 'Source',
 						id: 'source',
 						default: '0',
+						allowCustom: true,
 						choices: this.CHOICES_INPUTS,
 					},
 				],
@@ -251,6 +252,7 @@ class instance extends instance_skel {
 						label: 'Source',
 						id: 'source',
 						default: '0',
+						allowCustom: true,
 						choices: this.CHOICES_INPUTS,
 					},
 				],
@@ -263,6 +265,7 @@ class instance extends instance_skel {
 						label: 'Source',
 						id: 'source',
 						default: '0',
+						allowCustom: true,
 						choices: this.CHOICES_INPUTS,
 					},
 				],
@@ -380,6 +383,7 @@ class instance extends instance_skel {
 						label: 'Source',
 						id: 'source',
 						default: '0',
+						allowCustom: true,
 						choices: this.CHOICES_INPUTS,
 					},
 				],
@@ -515,13 +519,13 @@ class instance extends instance_skel {
 
 		switch (action.action) {
 			case 'select_pgm':
-				cmd = 'PGM:' + options.source
+				cmd = 'PGM:'
 				break
 			case 'select_pvw':
-				cmd = 'PST:' + options.source
+				cmd = 'PST:'
 				break
 			case 'select_aux':
-				cmd = 'AUX:' + options.source
+				cmd = 'AUX:'
 				break
 			case 'select_transition_effect':
 				cmd = 'TRS:' + options.transitioneffect
@@ -566,7 +570,7 @@ class instance extends instance_skel {
 				cmd = 'SPT:' + options.value1 + ',' + options.value2
 				break
 			case 'dsk_selectsource':
-				cmd = 'DSS:' + options.source
+				cmd = 'DSS:'
 				break
 			case 'dsk_keylevel':
 				cmd = 'KYL:' + options.level
@@ -596,7 +600,14 @@ class instance extends instance_skel {
 				cmd = 'MEM:' + options.preset
 				break
 		}
-		this.sendCommmand(cmd)
+
+		if ('source' in options) {
+			this.parseVariables(options.source, (src) => {
+				this.sendCommmand(cmd + src);
+			});
+		} else {
+			this.sendCommmand(cmd)
+		}
 	}
 
 	initFeedbacks() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "roland-v60hd",
-	"version": "1.0.12",
+	"version": "1.0.13",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Vision Mixer",


### PR DESCRIPTION
It seems the V-60 doesn't like to receive more than one command at once. We've been having issues where the device will stop responding completely until it is manually rebooted. This should prevent that from happening.

This fix will add a command buffer and only send one command per each ACK. In addition, we will no longer send multiple poll commands and will wait for all of the buffer to clear before sending more.

From the manual:
> When sending a sequence of commands to the V-60HD from a controller, after each one, be sure to verify that an “ACK” response is returned before sending the next command.

This will also allow for disabling the polling, since that doesn't appear to work correctly on our V-60, but it could just be an issue with our V-60.

This will also allow sources to use custom variables.